### PR TITLE
Fixed icons for Windows 10

### DIFF
--- a/Unpaint/DownloadModelDialog.xaml
+++ b/Unpaint/DownloadModelDialog.xaml
@@ -28,7 +28,7 @@
       <RowDefinition Height="Auto"/>
     </Grid.RowDefinitions>
 
-    <FontIcon Grid.Column="0" Grid.RowSpan="2" FontFamily="Segoe Fluent Icons" FontSize="36" Glyph="&#xebd3;" Visibility="{x:Bind ViewModel.IsInProgress, Mode=OneWay}" Margin="0,0,12,0"/>
+    <FontIcon Grid.Column="0" Grid.RowSpan="2" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="36" Glyph="&#xebd3;" Visibility="{x:Bind ViewModel.IsInProgress, Mode=OneWay}" Margin="0,0,12,0"/>
     <TextBlock Grid.Column="1" Grid.Row="0" Text="{x:Bind ViewModel.StatusMessage, Mode=OneWay}" VerticalAlignment="Bottom"/>
     <muxc:ProgressBar Grid.Column="1" Grid.Row="1" Value="{x:Bind ViewModel.Progress, Mode=OneWay}" Maximum="1" VerticalAlignment="Top" Visibility="{x:Bind ViewModel.IsInProgress, Mode=OneWay}"/>
   </Grid>

--- a/Unpaint/InferenceView.xaml
+++ b/Unpaint/InferenceView.xaml
@@ -233,7 +233,7 @@
           <Image Source="{x:Bind ViewModel.InputImage, Converter={StaticResource StorageFileToImageSourceConverter}, Mode=OneWay}"/>
         </local:MaskEditor>
 
-        <Button Margin="6,0,-36,0" Width="30" Height="30" HorizontalAlignment="Right" VerticalAlignment="Center" Content="&#xe76b;" FontFamily="Segoe Fluent Icons" Padding="0"
+        <Button Margin="6,0,-36,0" Width="30" Height="30" HorizontalAlignment="Right" VerticalAlignment="Center" Content="&#xe76b;" FontFamily="{StaticResource SymbolThemeFontFamily}" Padding="0"
                 Click="{x:Bind ViewModel.UseCurrentImageAsInput}" IsEnabled="{x:Bind ViewModel.HasImageSelected, Mode=OneWay}" ToolTipService.ToolTip="Use current image as input"/>
       </Grid>
 
@@ -288,7 +288,7 @@
           </Grid.ColumnDefinitions>
 
           <!-- Open input pane -->
-          <Button Grid.Column="0" FontFamily="Segoe Fluent Icons" FontSize="20" Content="&#xe91b;" Style="{StaticResource FlatButtonStyle}"
+          <Button Grid.Column="0" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="20" Content="&#xe91b;" Style="{StaticResource FlatButtonStyle}"
                   Click="{x:Bind ToggleInputPane}">
             <ToolTipService.ToolTip>
               <StackPanel>
@@ -301,7 +301,7 @@
           <!-- Denoising strength -->
           <Slider Grid.Column="1" Minimum="0" Maximum="1" SmallChange="0.01" LargeChange="0.1" StepFrequency="0.01" VerticalAlignment="Center" Margin="6,-10"
                   Value="{x:Bind ViewModel.DenoisingStrength, Mode=TwoWay}"/>
-          <FontIcon Grid.Column="2" FontFamily="Segoe Fluent Icons" FontSize="20" Glyph="&#xf4a5;" VerticalAlignment="Center" Margin="6,-10,0,-10">
+          <FontIcon Grid.Column="2" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="20" Glyph="&#xf4a5;" VerticalAlignment="Center" Margin="6,-10,0,-10">
             <ToolTipService.ToolTip>
               <StackPanel>
                 <TextBlock Text="Denoising strength" FontWeight="Bold"/>
@@ -326,14 +326,14 @@
 
         <!-- General controls -->
         <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="6">
-          <Button FontFamily="Segoe Fluent Icons" FontSize="20" Content="&#xe71b;" Style="{StaticResource FlatButtonStyle}" ToolTipService.ToolTip="Copy prompt link to clipboard."
+          <Button FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="20" Content="&#xe71b;" Style="{StaticResource FlatButtonStyle}" ToolTipService.ToolTip="Copy prompt link to clipboard."
                   Click="{x:Bind ViewModel.CopyPromptLink}"/>
-          <Button FontFamily="Segoe Fluent Icons" FontSize="20" Content="&#xe92f;" Style="{StaticResource FlatButtonStyle}" ToolTipService.ToolTip="Copy generation settings from the current image."
+          <Button FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="20" Content="&#xe92f;" Style="{StaticResource FlatButtonStyle}" ToolTipService.ToolTip="Copy generation settings from the current image."
                   Click="{x:Bind ViewModel.LoadSettingsFromCurrentImage}" IsEnabled="{x:Bind ViewModel.HasImageSelected, Mode=OneWay}"/>
-          <ToggleSwitch FontFamily="Segoe Fluent Icons" FontSize="20" OnContent="&#xe718;" OffContent="&#xe77a;" VerticalAlignment="Center" Margin="0,-10" Background="Transparent"
+          <ToggleSwitch FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="20" OnContent="&#xe718;" OffContent="&#xe77a;" VerticalAlignment="Center" Margin="0,-10" Background="Transparent"
                         IsOn="{x:Bind ViewModel.IsSettingsLocked, Mode=TwoWay}" Style="{StaticResource FlatToggleSwitchStyle}" PointerPressed="{x:Bind ToggleSettingsLock}"
                         ToolTipService.ToolTip="Lock custom settings or show the settings used for generating the selected image."/>
-          <ToggleSwitch FontFamily="Segoe Fluent Icons" FontSize="20" OnContent="&#xe893;" OffContent="&#xe769;" VerticalAlignment="Center" Margin="0,-10" Background="Transparent"
+          <ToggleSwitch FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="20" OnContent="&#xe893;" OffContent="&#xe769;" VerticalAlignment="Center" Margin="0,-10" Background="Transparent"
                         IsOn="{x:Bind ViewModel.IsJumpingToLatestImage, Mode=TwoWay}" Style="{StaticResource FlatToggleSwitchStyle}" PointerPressed="{x:Bind ToggleJumpingToLatestImage}"
                         ToolTipService.ToolTip="Go to the latest image after generation or keep showing the current image."/>
         </StackPanel>
@@ -355,7 +355,7 @@
         </Grid.RowDefinitions>
 
         <!-- Inference settings -->
-        <Button Grid.Column="0" Grid.RowSpan="2" FontFamily="Segoe Fluent Icons" FontSize="24" Content="&#xe9e9;" ToolTipService.ToolTip="Inference Options" VerticalAlignment="Stretch">
+        <Button Grid.Column="0" Grid.RowSpan="2" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="24" Content="&#xe9e9;" ToolTipService.ToolTip="Inference Options" VerticalAlignment="Stretch">
           <Button.Flyout>
             <Flyout>
               <Grid ColumnSpacing="12" RowSpacing="6">
@@ -395,7 +395,7 @@
 
                   <ComboBox ItemsSource="{x:Bind ViewModel.Models, Mode=OneWay}"
                             SelectedIndex="{x:Bind ViewModel.SelectedModelIndex, Mode=TwoWay}"/>
-                  <Button Grid.Column="1" FontFamily="Segoe Fluent Icons" Content="&#xe8f1;" ToolTipService.ToolTip="Manage models" VerticalAlignment="Stretch"
+                  <Button Grid.Column="1" FontFamily="{StaticResource SymbolThemeFontFamily}" Content="&#xe8f1;" ToolTipService.ToolTip="Manage models" VerticalAlignment="Stretch"
                           Click="{x:Bind ViewModel.ManageModels}"/>
                 </Grid>
 
@@ -442,7 +442,7 @@
                   </Grid.ColumnDefinitions>
 
                   <muxc:NumberBox Value="{x:Bind ViewModel.RandomSeed, Mode=TwoWay}"/>
-                  <ToggleButton Grid.Column="1" FontFamily="Segoe Fluent Icons" Content="&#xe72e;" ToolTipService.ToolTip="Freeze seed" VerticalAlignment="Stretch"
+                  <ToggleButton Grid.Column="1" FontFamily="{StaticResource SymbolThemeFontFamily}" Content="&#xe72e;" ToolTipService.ToolTip="Freeze seed" VerticalAlignment="Stretch"
                                 IsChecked="{x:Bind ViewModel.IsSeedFrozen, Mode=TwoWay}"/>
                 </Grid>
               </Grid>
@@ -462,7 +462,7 @@
           </ToolTipService.ToolTip>
         </TextBox>
         <TextBlock Grid.Column="1" Grid.Row="0" Text="{x:Bind ViewModel.AvailablePositiveTokenCount, Mode=OneWay}" Style="{StaticResource AvailableTokenCountStyle}"/>
-        <FontIcon Grid.Column="1" Grid.Row="0" FontFamily="Segoe Fluent Icons" FontSize="20" Glyph="&#xe948;" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10,6,0,0"/>
+        <FontIcon Grid.Column="1" Grid.Row="0" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="20" Glyph="&#xe948;" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10,6,0,0"/>
 
         <!-- Negative prompt -->
         <TextBox Grid.Column="1" Grid.Row="1" TextWrapping="Wrap" Padding="36,4,25,0"
@@ -476,7 +476,7 @@
           </ToolTipService.ToolTip>
         </TextBox>
         <TextBlock Grid.Column="1" Grid.Row="1" Text="{x:Bind ViewModel.AvailableNegativeTokenCount, Mode=OneWay}" Style="{StaticResource AvailableTokenCountStyle}"/>
-        <FontIcon Grid.Column="1" Grid.Row="1" FontFamily="Segoe Fluent Icons" FontSize="20" Glyph="&#xe949;" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10,6,0,0"/>
+        <FontIcon Grid.Column="1" Grid.Row="1" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="20" Glyph="&#xe949;" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10,6,0,0"/>
 
         <!-- Execute -->
         <Button Grid.Column="2" Grid.RowSpan="2" VerticalAlignment="Stretch" Click="{x:Bind ViewModel.GenerateImage}">
@@ -487,7 +487,7 @@
             </StackPanel>
           </ToolTipService.ToolTip>
           <Button.Content>
-            <FontIcon Glyph="{x:Bind ViewModel.IsAutoGenerationEnabled, Converter={StaticResource BooleanToGenerateIconConverter}, Mode=OneWay}" FontFamily="Segoe Fluent Icons" FontSize="24"/>
+            <FontIcon Glyph="{x:Bind ViewModel.IsAutoGenerationEnabled, Converter={StaticResource BooleanToGenerateIconConverter}, Mode=OneWay}" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="24"/>
           </Button.Content>
           <Button.KeyboardAccelerators>
             <KeyboardAccelerator Key="Enter"/>

--- a/Unpaint/MaskEditor.xaml
+++ b/Unpaint/MaskEditor.xaml
@@ -47,7 +47,7 @@
             <!-- Brush size -->
             <Slider Orientation="Vertical" MinHeight="128" Margin="-32,6" Minimum="1" Maximum="128" HorizontalAlignment="Center"
                     Value="{x:Bind BrushSize, Mode=TwoWay}"/>
-            <FontIcon Glyph="&#xeda8;" FontFamily="Segoe Fluent Icons" HorizontalAlignment="Center" ToolTipService.ToolTip="Brush size"/>
+            <FontIcon Glyph="&#xeda8;" FontFamily="{StaticResource SymbolThemeFontFamily}" HorizontalAlignment="Center" ToolTipService.ToolTip="Brush size"/>
 
             <!-- Separator -->
             <Border Background="{ThemeResource ControlElevationBorderBrush}" Height="1" Margin="-2,6"/>
@@ -55,7 +55,7 @@
             <!-- Edge thickness -->
             <Slider Orientation="Vertical" MinHeight="64" Margin="-32,6" Minimum="0" Maximum="16" SmallChange="1" StepFrequency="1" HorizontalAlignment="Center"
                     Value="{x:Bind BrushEdge, Mode=TwoWay}"/>
-            <FontIcon Glyph="&#xe81d;" FontFamily="Segoe Fluent Icons" HorizontalAlignment="Center" ToolTipService.ToolTip="Edge thickness"/>
+            <FontIcon Glyph="&#xe81d;" FontFamily="{StaticResource SymbolThemeFontFamily}" HorizontalAlignment="Center" ToolTipService.ToolTip="Edge thickness"/>
 
             <!-- Separator -->
             <Border Background="{ThemeResource ControlElevationBorderBrush}" Height="1" Margin="-2,6"/>

--- a/Unpaint/ModelsView.xaml
+++ b/Unpaint/ModelsView.xaml
@@ -17,7 +17,7 @@
       </Grid.ColumnDefinitions>
 
       <TextBlock Text="Model Library" Style="{StaticResource TitleTextBlockStyle}" VerticalAlignment="Center"/>
-      <FontIcon Grid.Column="1" FontFamily="Segoe Fluent Icons" FontSize="48" Glyph="&#xe8f1;" VerticalAlignment="Center"/>
+      <FontIcon Grid.Column="1" FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="48" Glyph="&#xe8f1;" VerticalAlignment="Center"/>
     </Grid>
 
     <!-- Introduction -->
@@ -49,8 +49,8 @@
         </Grid.ColumnDefinitions>
         <TextBlock Text="Available models" VerticalAlignment="Center"/>
         <StackPanel Orientation="Horizontal" Grid.Column="1" Spacing="6">
-          <Button FontFamily="Segoe Fluent Icons" Content="&#xe946;" ToolTipService.ToolTip="Open model website" Click="{x:Bind ViewModel.OpenAvailableModelWebsite}" IsEnabled="{x:Bind ViewModel.IsAvailableModelSelected, Mode=OneWay}"/>
-          <Button FontFamily="Segoe Fluent Icons" Content="&#xe72c;" ToolTipService.ToolTip="Refresh" Click="{x:Bind ViewModel.UpdateAvailableModelsAsync}"/>
+          <Button FontFamily="{StaticResource SymbolThemeFontFamily}" Content="&#xe946;" ToolTipService.ToolTip="Open model website" Click="{x:Bind ViewModel.OpenAvailableModelWebsite}" IsEnabled="{x:Bind ViewModel.IsAvailableModelSelected, Mode=OneWay}"/>
+          <Button FontFamily="{StaticResource SymbolThemeFontFamily}" Content="&#xe72c;" ToolTipService.ToolTip="Refresh" Click="{x:Bind ViewModel.UpdateAvailableModelsAsync}"/>
         </StackPanel>
       </Grid>
       
@@ -71,8 +71,8 @@
 
       <!-- Middle section -->
       <StackPanel Grid.Column="1" Grid.Row="1" VerticalAlignment="Center" Spacing="12">
-        <Button FontFamily="Segoe Fluent Icons" FontSize="24" Content="&#xe76c;" ToolTipService.ToolTip="Add model" Click="{x:Bind ViewModel.DownloadModelAsync}" IsEnabled="{x:Bind ViewModel.IsAvailableModelSelected, Mode=OneWay}"/>
-        <Button FontFamily="Segoe Fluent Icons" FontSize="24" Content="&#xe76b;" ToolTipService.ToolTip="Remove model" Click="{x:Bind ViewModel.RemoveModelAsync}" IsEnabled="{x:Bind ViewModel.IsInstalledModelSelected, Mode=OneWay}"/>
+        <Button FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="24" Content="&#xe76c;" ToolTipService.ToolTip="Add model" Click="{x:Bind ViewModel.DownloadModelAsync}" IsEnabled="{x:Bind ViewModel.IsAvailableModelSelected, Mode=OneWay}"/>
+        <Button FontFamily="{StaticResource SymbolThemeFontFamily}" FontSize="24" Content="&#xe76b;" ToolTipService.ToolTip="Remove model" Click="{x:Bind ViewModel.RemoveModelAsync}" IsEnabled="{x:Bind ViewModel.IsInstalledModelSelected, Mode=OneWay}"/>
       </StackPanel>
 
       <!-- Installed models -->
@@ -83,8 +83,8 @@
         </Grid.ColumnDefinitions>
         <TextBlock Text="Installed models" VerticalAlignment="Center"/>
         <StackPanel Orientation="Horizontal" Grid.Column="1" Spacing="6">
-          <Button FontFamily="Segoe Fluent Icons" Content="&#xe946;" ToolTipService.ToolTip="Open model website" Click="{x:Bind ViewModel.OpenInstalledModelWebsite}" IsEnabled="{x:Bind ViewModel.IsInstalledModelSelected, Mode=OneWay}"/>
-          <Button FontFamily="Segoe Fluent Icons" Content="&#xe838;" ToolTipService.ToolTip="Open model directory" Click="{x:Bind ViewModel.OpenModelDirectory}"/>
+          <Button FontFamily="{StaticResource SymbolThemeFontFamily}" Content="&#xe946;" ToolTipService.ToolTip="Open model website" Click="{x:Bind ViewModel.OpenInstalledModelWebsite}" IsEnabled="{x:Bind ViewModel.IsInstalledModelSelected, Mode=OneWay}"/>
+          <Button FontFamily="{StaticResource SymbolThemeFontFamily}" Content="&#xe838;" ToolTipService.ToolTip="Open model directory" Click="{x:Bind ViewModel.OpenModelDirectory}"/>
         </StackPanel>
       </Grid>
       

--- a/Unpaint/SettingControl.xaml
+++ b/Unpaint/SettingControl.xaml
@@ -24,7 +24,7 @@
           <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
 
-        <FontIcon Grid.RowSpan="2" FontFamily="Segoe Fluent Icons" Glyph="{x:Bind Icon, Mode=OneWay}"/>
+        <FontIcon Grid.RowSpan="2" FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="{x:Bind Icon, Mode=OneWay}"/>
 
         <TextBlock Grid.Row="0" Grid.Column="1" Text="{x:Bind Title, Mode=OneWay}"/>
         <TextBlock Grid.Row="1" Grid.Column="1" Text="{x:Bind Subtitle, Mode=OneWay}" FontSize="14" Opacity="0.5" TextWrapping="Wrap"/>

--- a/Unpaint/SettingsView.xaml
+++ b/Unpaint/SettingsView.xaml
@@ -50,11 +50,11 @@
       </local:SettingControl>
 
       <local:SettingControl Icon="&#xebe8;" Title="Feedback &amp; support" Subtitle="If the application fails to run, generates unintended NSFW content or you have a suggested feature continue here.">
-        <HyperlinkButton Content="&#xe8a7;" FontFamily="Segoe Fluent Icons" NavigateUri="https://github.com/axodox/unpaint/issues"/>
+        <HyperlinkButton Content="&#xe8a7;" FontFamily="{StaticResource SymbolThemeFontFamily}" NavigateUri="https://github.com/axodox/unpaint/issues"/>
       </local:SettingControl>
 
       <local:SettingControl Icon="&#xedfb;" Title="Report a copyright violation" Subtitle="Opens the source page of the current model. Please note that Unpaint is just an execution engine, it does not hold any data from which the images are derived.">
-        <HyperlinkButton Content="&#xe8a7;" FontFamily="Segoe Fluent Icons" NavigateUri="{x:Bind ViewModel.SelectedModelUri}"/>
+        <HyperlinkButton Content="&#xe8a7;" FontFamily="{StaticResource SymbolThemeFontFamily}" NavigateUri="{x:Bind ViewModel.SelectedModelUri}"/>
       </local:SettingControl>
 
       <Button Content="Continue" HorizontalAlignment="Center" Click="{x:Bind ViewModel.Continue}"/>


### PR DESCRIPTION
Updated `"Segoe Fluent Icons"` to `"{StaticResource SymbolThemeFontFamily}"`

Should fix #13 and #19